### PR TITLE
fix: update execution behavior of interceptor

### DIFF
--- a/ask-sdk-core/lib/skill/Skill.ts
+++ b/ask-sdk-core/lib/skill/Skill.ts
@@ -52,6 +52,8 @@ export class Skill {
             requestMappers : skillConfiguration.requestMappers,
             handlerAdapters : skillConfiguration.handlerAdapters,
             errorMapper : skillConfiguration.errorMapper,
+            requestInterceptors : skillConfiguration.requestInterceptors,
+            responseInterceptors : skillConfiguration.responseInterceptors,
         });
     }
 

--- a/ask-sdk-core/lib/skill/SkillConfiguration.ts
+++ b/ask-sdk-core/lib/skill/SkillConfiguration.ts
@@ -17,6 +17,8 @@ import { services } from 'ask-sdk-model';
 import { PersistenceAdapter } from '../attributes/persistence/PersistenceAdapter';
 import { ErrorMapper } from '../dispatcher/error/ErrorMapper';
 import { HandlerAdapter } from '../dispatcher/request/handler/HandlerAdapter';
+import { RequestInterceptor } from '../dispatcher/request/interceptor/RequestInterceptor';
+import { ResponseInterceptor } from '../dispatcher/request/interceptor/ResponseInterceptor';
 import { RequestMapper } from '../dispatcher/request/mapper/RequestMapper';
 
 /**
@@ -26,6 +28,8 @@ export interface SkillConfiguration {
     requestMappers : RequestMapper[];
     handlerAdapters : HandlerAdapter[];
     errorMapper? : ErrorMapper;
+    requestInterceptors? : RequestInterceptor[];
+    responseInterceptors? : ResponseInterceptor[];
     persistenceAdapter? : PersistenceAdapter;
     apiClient? : services.ApiClient;
     customUserAgent? : string;


### PR DESCRIPTION
This commit contains changes to the execution order of interceptors.
Now, the request interceptors registered from SkillBuilders will be executed
before request handler's canhandle is invoked. Response interceptors will be executed
immediately after request handler's handle returns.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa/alexa-skills-kit-sdk-for-nodejs/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
